### PR TITLE
Improve plugin

### DIFF
--- a/modern-font-stacks-for-wp.php
+++ b/modern-font-stacks-for-wp.php
@@ -29,7 +29,9 @@ function mfswp_add_modern_font_stacks( $theme_json ) {
 	$current_data = $theme_json->get_data();
 
 	// bail if theme.json version is not version 2 (TODO: maybe show an admin notice that the plugin does not work?)
-	if ( empty( $current_data ) || ! isset( $current_data['version'] ) || ( $current_data['version'] !== 2 ) ) return $theme_json;
+	if ( ! isset( $current_data['version'] ) || $current_data['version'] !== 2 ) {
+		return $theme_json;
+	}
 
 	// get currently available font families
 	$current_font_families = $current_data['settings']['typography']['fontFamilies']['theme'];
@@ -74,7 +76,7 @@ add_action( 'after_setup_theme', 'mfswp_apply_theme_json_theme_filter' );
  */
 function mfswp_get_modern_font_stacks() {
 
-	$modern_font_stacks = array (
+	return array (
 		array (
 			'fontFamily' => 'system-ui, sans-serif',
 			'name' => 'System UI',
@@ -151,6 +153,4 @@ function mfswp_get_modern_font_stacks() {
 			'slug' => 'mfswp-handwritten'
 		)
 	);
-
-	return $modern_font_stacks;
 }


### PR DESCRIPTION
- `isset` will always fail when `empty` fails, thus it is redundant
- remove a temporary variable
